### PR TITLE
Map Example, public init for Wrapper.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Wrapper",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v15)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/Examples/Map/MapView.swift
+++ b/Sources/Examples/Map/MapView.swift
@@ -1,0 +1,24 @@
+//
+//  MapView.swift
+//  
+//
+//  Created by Kostiantyn Nevinchanyi on 3/14/23.
+//
+
+import SwiftUI
+
+struct MapView: View {
+    
+    @StateObject var viewModel = MapViewModel()
+    
+    var body: some View {
+        WrapperView(view: viewModel.mapView)
+    }
+}
+
+struct MapView_Previews: PreviewProvider {
+    static var previews: some View {
+        MapView()
+    }
+}
+

--- a/Sources/Examples/Map/MapViewModel.swift
+++ b/Sources/Examples/Map/MapViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  MapViewModel.swift
+//  
+//
+//  Created by Kostiantyn Nevinchanyi on 3/14/23.
+//
+
+import Foundation
+import MapKit
+
+class MapViewModel: NSObject, ObservableObject {
+    
+    let mapView: MKMapView
+    
+    init(mapView: MKMapView = MKMapView()) {
+        self.mapView = mapView
+    }
+}

--- a/Sources/Wrapper/WrapperView.swift
+++ b/Sources/Wrapper/WrapperView.swift
@@ -13,6 +13,11 @@ public struct WrapperView<V: UIView>: UIViewRepresentable {
     public var view: V
     public var onUpdate: ((V) -> Void)?
     
+    public init(view: V, onUpdate: ((V) -> Void)? = nil) {
+        self.view = view
+        self.onUpdate = onUpdate
+    }
+    
     public func makeUIView(context: Context) -> V {
         return view
     }


### PR DESCRIPTION
Add example of how to use Wrapper with MKMapView (MapKit). Fix: Add public init for Wrapper.